### PR TITLE
better similarity with chi2_distance

### DIFF
--- a/color_profiling.py
+++ b/color_profiling.py
@@ -6,7 +6,6 @@ import numpy as np
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 import time
-import cv2  # OpenCV
 from multiprocessing import Pool, cpu_count
 
 # Funktion zur Extraktion des RGB-Histogramms eines Bildes
@@ -18,20 +17,17 @@ def extract_histogram(image_path):
         histogram = np.array(histogram) / (224 * 224)  # Normalisieren
         return histogram
 
-
 # Funktion zur Berechnung der Chi-Quadrat-Distanz zwischen zwei Histogrammen
 def chi2_distance(args):
     histA, histB = args
     eps = 1e-10
     return 0.5 * np.sum(((histA - histB) ** 2) / (histA + histB + eps))
 
-
 # Funktion zum Laden der Histogramme aus einer Pickle-Datei
 def load_histograms(pickle_file):
     with open(pickle_file, "rb") as f:
         histograms = pickle.load(f)
     return histograms
-
 
 # Funktion zum Finden der 5 ähnlichsten Bilder für ein Eingabebild
 def find_similar_images_for_one_input(input_histogram, histograms, top_n=5):
@@ -43,7 +39,6 @@ def find_similar_images_for_one_input(input_histogram, histograms, top_n=5):
     image_paths = list(histograms.keys())
     sorted_images = sorted(zip(image_paths, similarities), key=lambda item: item[1])
     return [img[0] for img in sorted_images[:top_n]]
-
 
 # Funktion zur Anzeige der Bilder
 def display_images(image_groups):
@@ -59,7 +54,6 @@ def display_images(image_groups):
                     print(f"Error loading image {image_path}: {e}")
     plt.show()
 
-
 # Funktion zum Abrufen der Bildpfade aus der Datenbank basierend auf der ID
 def get_image_path_from_db(image_id, conn):
     cursor = conn.cursor()
@@ -68,7 +62,6 @@ def get_image_path_from_db(image_id, conn):
     if result:
         return result[0]
     return None
-
 
 # Hauptfunktion
 def main():
@@ -117,6 +110,11 @@ def main():
                 similar_image_paths.append(similar_image_path)
             else:
                 print(f"Image path not found in database for ID {img_id}")
+
+        # Ausgabe der Dateipfade der ähnlichen Bilder
+        print(f"Similar images for {input_image_path}:")
+        for path in similar_image_paths:
+            print(path)
 
         all_similar_image_groups.append(similar_image_paths)
 


### PR DESCRIPTION
the output of the similarities looks better and you can see a similarity, the performance got better with parallesing, by 30 sec saving

The chi-square distance measures the similarity between the color distributions of two images. A smaller value of the chi-square distance means a greater similarity between the histograms and therefore between the images. The calculation is parallelized in your code to improve efficiency, especially with large data sets.

Explanation of the individual lines
Unpacking the arguments: histA, histB = args
The function chi2_distance is called with a tuple (histA, histB) containing the two histograms to be compared.
Small value eps: eps = 1e-10
eps is a small value that is used to avoid division by zero.
Calculation of the chi-square distance:
histA - histB: Calculation of the difference of the bins.
(histA - histB) ** 2: Squaring the differences.
histA + histB + eps: Calculating the sum of the bins and adding eps.
((histA - histB) ** 2) / (histA + histB + eps): Dividing the squared differences by the sums.
np.sum(...): Summing all results of the bins.
0.5 * ...: Multiplying the sum value by 0.5 to calculate the final chi-squared distance.